### PR TITLE
Support for nf-core/viralrecon v2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,16 @@
 History
 =======
 
+0.4.2 (2021-05-21)
+------------------
+
+* Add support for nf-core/viralrecon version 2.0 (requires Mosdepth ``bed.gz`` files be output; needs custom ``modules.config`` like `this one <https://gist.github.com/peterk87/495621349c1161d12047c1c8f97935af>`_)
+* `Nextclade CLI <https://github.com/nextstrain/nextclade/blob/master/packages/cli/README.md>`_ per sample results parsed into sheet showing useful info like Nextstrain clade, # of mutations, # of PCR primer changes
+* Added check that input directory exists and is a directory
+* Added sheet with xlavir info
+* Added Gene, Variant Effect, Variant Impact, Amino Acid Change to Variant Summary table
+
+
 0.4.1 (2021-05-14)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.4.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/peterk87/xlavir',
-    version='0.4.1',
+    version='0.4.2',
     zip_safe=False,
 )

--- a/xlavir/__init__.py
+++ b/xlavir/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Peter Kruczkiewicz"""
 __email__ = 'peter.kruczkiewicz@gmail.com'
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/xlavir/io/excel_sheet_dataframe.py
+++ b/xlavir/io/excel_sheet_dataframe.py
@@ -12,6 +12,8 @@ class SheetName(str, Enum):
     variants = 'Variants'
     varsum = 'Variants Summary'
     varmat = 'Variant Matrix'
+    nextclade = 'Nextclade'
+    xlavir_info = 'xlavir info'
 
 
 class ExcelSheetDataFrame:

--- a/xlavir/tools/nextclade.py
+++ b/xlavir/tools/nextclade.py
@@ -1,0 +1,257 @@
+import logging
+import re
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+from xlavir.util import find_file_for_each_sample
+
+logger = logging.getLogger(__name__)
+
+nextclade_cols = [
+    (
+        'seqName',
+        'Sample',
+        'Sample name.',
+    ),
+    (
+        'clade',
+        'Clade',
+        'The result of the clade assignment of a sequence, as defined by Nextstrain. ',
+    ),
+    # STATUS
+    (
+        'qc.overallStatus',
+        'QC: Overall Status',
+        'Overall quality control assessment status by Nextclade',
+    ),
+    (
+        'qc.missingData.status',
+        'QC: Missing Data Status',
+        'Missing data status according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.mixedSites.status',
+        'QC: Mixed Sites Status',
+        'Mixed sites status according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.privateMutations.status',
+        'QC: Private Mutations Status',
+        'Private mutations status according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.snpClusters.status',
+        'QC: Mutation Clusters Status',
+        'Mutation clusters status according to Nextclade quality control assessment.',
+    ),
+    # TOTALS
+    (
+        'totalGaps',
+        '# Gaps',
+        'Number of `-` characters (gaps) in the sequence.',
+    ),
+    (
+        'totalInsertions',
+        '# Insertions',
+        'Number of insertions in the sequence.',
+    ),
+    (
+        'totalMissing',
+        '# Missing',
+        'Number of missing sites in the sequence.',
+    ),
+    (
+        'totalMutations',
+        '# Mutations',
+        'Number of mutations in the sequence relative to Wuhan-Hu-1 (MN908947.3) SARS-CoV-2 sequence.',
+    ),
+    (
+        'totalNonACGTNs',
+        '# non-ACGTN',
+        'Number of non-nucleotide (A, C, G, or T) or N characters in the sequence.',
+    ),
+    (
+        'totalPcrPrimerChanges',
+        '# PCR primer changes',
+        'Total number of changes to known PCR primers as a result of mutations.',
+    ),
+    (
+        'totalAminoacidSubstitutions',
+        '# Amino Acid Substitutions',
+        'Number of amino acid substitution mutations in the sequence.',
+    ),
+    (
+        'totalAminoacidDeletions',
+        '# Amino Acid Deletions',
+        'Number of amino acid deletion mutations in the sequence.',
+    ),
+    (
+        'qc.missingData.totalMissing',
+        'QC: # Missing Data',
+        'Number of missing data sites according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.mixedSites.totalMixedSites',
+        'QC: # Mixed Sites',
+        'Number of mixed sites according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.privateMutations.total',
+        'QC: # Private Mutations',
+        'Number of private mutations according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.snpClusters.totalSNPs',
+        'QC: # Mutation Clusters',
+        'Number of mutation clusters according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.privateMutations.excess',
+        'QC: Private Mutations Excess',
+        'Number of excess private mutations according to Nextclade quality control assessment.',
+    ),
+    # LISTS
+    (
+        'substitutions',
+        'Substitutions',
+        'List of substitution mutations in the sequence.',
+    ),
+    (
+        'deletions',
+        'Deletions',
+        'List of deletion mutations in the sequence.',
+    ),
+    (
+        'insertions',
+        'Insertions',
+        'List of insertion mutations in the sequence.',
+    ),
+    (
+        'missing',
+        'Missing',
+        'List of missing sites in the sequence.',
+    ),
+    (
+        'nonACGTNs',
+        'nonACGTNs',
+        'List of non-ACGTN sites in the sequence.',
+    ),
+    (
+        'pcrPrimerChanges',
+        'PCR primer changes',
+        'List of PCR primer changes in the sequence.',
+    ),
+    (
+        'aaSubstitutions',
+        'Amino Acid Substitutions',
+        'List of amino acid substitution mutations in the sequence.',
+    ),
+    (
+        'aaDeletions',
+        'Amino Acid Deletions',
+        'List of amino acid deletion mutations in the sequence.',
+    ),
+    (
+        'qc.snpClusters.clusteredSNPs',
+        'QC: Mutation Clusters',
+        'Clustered mutations according to Nextclade quality control assessment.',
+    ),
+    # THRESHOLDS
+    (
+        'qc.missingData.missingDataThreshold',
+        'QC: Missing Data Threshold',
+        'Missing data threshold according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.mixedSites.mixedSitesThreshold',
+        'QC: Mixed Sites Threshold',
+        'Threshold for number of mixed sites for Nextclade quality control assessment.',
+    ),
+    (
+        'qc.privateMutations.cutoff',
+        'QC: Private Mutations Cutoff',
+        'Cutoff for number of private mutations for Nextclade quality control assessment.',
+    ),
+    # SCORE
+    (
+        'qc.overallScore',
+        'QC: Overall Score',
+        'Overall quality control assessment score by Nextclade',
+    ),
+    (
+        'qc.missingData.score',
+        'QC: Missing Data Score',
+        'Missing data score according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.mixedSites.score',
+        'QC: Mixed Sites Score',
+        'Mixed sites score according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.privateMutations.score',
+        'QC: Private Mutations Score',
+        'Private mutations score according to Nextclade quality control assessment.',
+    ),
+    (
+        'qc.snpClusters.score',
+        'QC: Mutation Clusters Score',
+        'Mutation clusters score according to Nextclade quality control assessment.',
+    ),
+    # ALIGNMENT
+    (
+        'alignmentEnd',
+        'Alignment End',
+        'Nextalign alignment end index.',
+    ),
+    (
+        'alignmentScore',
+        'Alignment Score',
+        'Nextalign alignment score.',
+    ),
+    (
+        'alignmentStart',
+        'Alignment Start',
+        'Nextalign alignment start.',
+    ),
+    (
+        'errors',
+        'Nextclade errors',
+        'Nextclade errors',
+    ),
+]
+
+NEXTCLADE_GLOB_PATTERNS = [
+    '**/nextclade/*.csv'
+]
+
+NEXTCLADE_SAMPLE_NAME_CLEANUP = [
+    re.compile(r'\.csv$')
+]
+
+
+def read_nextclade_csv(path: Path, sample_name: str) -> pd.DataFrame:
+    df = pd.read_csv(path, sep=';')
+    df.rename(columns={x: y for x, y, _ in nextclade_cols}, inplace=True)
+    df['Sample'] = sample_name
+    return df
+
+
+def get_info(basedir: Path) -> Dict[str, pd.DataFrame]:
+    sample_nextclade = find_file_for_each_sample(basedir=basedir,
+                                                 glob_patterns=NEXTCLADE_GLOB_PATTERNS,
+                                                 sample_name_cleanup=NEXTCLADE_SAMPLE_NAME_CLEANUP)
+    logger.info(f'Found {len(sample_nextclade)} Nextclade CSV files. Parsing...')
+    out = {}
+    for sample, nextclade_path in sample_nextclade.items():
+        out[sample] = read_nextclade_csv(nextclade_path, sample)
+    return out
+
+
+def to_dataframe(sample_nextclade: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+    df = pd.concat(list(sample_nextclade.values()))
+    df.sort_values('Sample', inplace=True)
+    df.set_index('Sample', inplace=True)
+    return df[[x for _,x,_ in nextclade_cols if x in df.columns]]

--- a/xlavir/tools/pangolin.py
+++ b/xlavir/tools/pangolin.py
@@ -1,7 +1,23 @@
+import re
 from pathlib import Path
 from typing import Optional
+import logging
 
 import pandas as pd
+
+from xlavir.util import find_file_for_each_sample
+
+logger = logging.getLogger(__name__)
+
+PANGOLIN_CSV = 'pangolin.lineage_report.csv'
+
+PANGOLIN_GLOB_PATTERNS = [
+    '**/*.pangolin.csv',
+]
+
+PANGOLIN_SAMPLE_NAME_CLEANUP = [
+    re.compile(r'\.pangolin\.csv$'),
+]
 
 pangolin_cols = [
     ('taxon', 'Sample', 'Sample name'),
@@ -16,6 +32,22 @@ pangolin_cols = [
         'Lineage Assignment Probability',
         'Pangolin lineage assignment probability from multinomial logistic regression. For more info, '
         'see https://github.com/cov-lineages/pangolin/#pangolearn-description'
+    ),
+    (
+        'conflict',
+        'Conflict',
+        'This is a measure of conflicts within the decision tree, 0 being '
+        'equivalent to no conflicts, but not a confidence score.'
+    ),
+    (
+        'pangolin_version',
+        'Pangolin Version',
+        'Version of Pangolin (https://github.com/cov-lineages/pangolin) used for lineage assignment.'
+    ),
+    (
+        'pango_version',
+        'Pango Version',
+        'pangoLEARN PANGO_VERSION (https://github.com/cov-lineages/pangoLEARN/)'
     ),
     (
         'pangoLEARN_version',
@@ -38,15 +70,16 @@ pangolin_cols = [
 
 
 def find_pangolin_lineage_csv(basedir: Path) -> Optional[Path]:
-    for p in basedir.rglob('pangolin.lineage_report.csv'):
+    for p in basedir.rglob(PANGOLIN_CSV):
         return p
 
 
-def read_pangolin_csv(path: Path) -> pd.DataFrame:
+def read_pangolin_csv(path: Path, sample_name: str = None) -> pd.DataFrame:
     df = pd.read_csv(path)
     df.sort_values('taxon', inplace=True)
-
     df.rename(columns={x: y for x, y, _ in pangolin_cols}, inplace=True)
+    if sample_name:
+        df['Sample'] = sample_name
     df.set_index('Sample', inplace=True)
     return df
 
@@ -59,3 +92,10 @@ def get_info(basedir: Path,
         path = find_pangolin_lineage_csv(basedir)
         if path:
             return read_pangolin_csv(path)
+        else:
+            logger.info(f'Could not find single Pangolin output CSV with filename "{PANGOLIN_CSV}". '
+                        f'Searching for Pangolin output per sample with sample name in filename')
+            pangolin_outputs = find_file_for_each_sample(basedir=basedir,
+                                                         glob_patterns=PANGOLIN_GLOB_PATTERNS,
+                                                         sample_name_cleanup=PANGOLIN_SAMPLE_NAME_CLEANUP)
+            return pd.concat([read_pangolin_csv(p, s) for s, p in pangolin_outputs.items()])

--- a/xlavir/tools/variants.py
+++ b/xlavir/tools/variants.py
@@ -170,11 +170,14 @@ VCF_SAMPLE_NAME_CLEANUP = [
 
 SNPSIFT_GLOB_PATTERNS = [
     '**/ivar/**/*.snpSift.table.txt',
+    '**/ivar/**/*.snpsift.txt',
     '**/*.snpSift.table.txt',
+    '**/*.snpsift.txt',
 ]
 
 SNPSIFT_SAMPLE_NAME_CLEANUP = [
-    re.compile(r'\.snpSift\.table\.txt$'),
+    re.compile(r'\.snp[sS]ift\.table\.txt$'),
+    re.compile(r'\.snp[sS]ift\.txt$'),
     re.compile(r'\.AF0\.\d+(\.filt)?'),
     re.compile(r'\.0\.\d+AF(\.filt)?'),
 ]
@@ -409,6 +412,8 @@ def get_info(basedir: Path) -> Dict[str, pd.DataFrame]:
                                                glob_patterns=SNPSIFT_GLOB_PATTERNS,
                                                sample_name_cleanup=SNPSIFT_SAMPLE_NAME_CLEANUP,
                                                single_entry_selector_func=snpsift_selector)
+    if sample_snpsift:
+        logger.warning(f'No SnpSift tables found in "{basedir}" using glob patterns "{SNPSIFT_GLOB_PATTERNS}"')
     sample_dfsnpsift = {}
     for sample, snpsift_path in sample_snpsift.items():
         df_snpsift = simplify_snpsift(pd.read_table(snpsift_path), sample)

--- a/xlavir/tools/variants.py
+++ b/xlavir/tools/variants.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Dict, Tuple, List, Optional, Iterable
 
 import pandas as pd
-import numpy as np
 from pydantic import BaseModel
 
 from xlavir.util import try_parse_number, find_file_for_each_sample
@@ -233,9 +232,16 @@ def parse_aa(gene: str,
              aa_pos: int,
              snpeff_aa: str,
              effect: str) -> str:
-    m = re.match(r'p\.([a-zA-Z]+)(\d+)([a-zA-Z]+)', snpeff_aa)
-    if snpeff_aa == '.' or m is None:
+    if snpeff_aa == '.':
         return f'{ref}{nt_pos}{alt}'
+    m = re.match(r'p\.([a-zA-Z]+)(\d+)([a-zA-Z]+)', snpeff_aa)
+    if m is None and snpeff_aa.startswith('p.'):
+        aa_str = snpeff_aa[2:].upper()
+        for aa3, aa1 in aa_codes.items():
+            aa_str = aa_str.replace(aa3, aa1)
+        if aa_str.endswith('DEL'):
+            aa_str = aa_str.replace('DEL', 'del')
+        return f'{ref}{nt_pos}{alt}({gene}:{aa_str})'
     ref_aa, aa_pos_str, alt_aa = m.groups()
     ref_aa = get_aa(ref_aa)
 
@@ -467,13 +473,17 @@ def to_summary(df: pd.DataFrame) -> pd.DataFrame:
     df_vars.reset_index(inplace=True)
 
     df_summary = df_vars.groupby('Mutation', sort=False).agg(
-        n_samples=pd.NamedAgg(column='Sample', aggfunc='size'),
-        samples=pd.NamedAgg(column='Sample', aggfunc=lambda x: '; '.join(x)),
-        min_depth=pd.NamedAgg(column='Alternate Allele Depth', aggfunc='min'),
-        max_depth=pd.NamedAgg(column='Alternate Allele Depth', aggfunc='max'),
-        mean_depth=pd.NamedAgg(column='Alternate Allele Depth', aggfunc=lambda x: sum(x) / len(x)),
-        min_af=pd.NamedAgg(column='Alternate Allele Frequency', aggfunc='min'),
-        max_af=pd.NamedAgg(column='Alternate Allele Frequency', aggfunc='max'),
-        mean_af=pd.NamedAgg(column='Alternate Allele Frequency', aggfunc=lambda x: sum(x) / len(x)),
+        n_samples=('Sample', 'size'),
+        samples=('Sample', lambda x: '; '.join(x)),
+        gene=('Gene', 'first'),
+        effect=('Variant Effect', 'first'),
+        impact=('Variant Impact', 'first'),
+        aa=('Amino Acid Change', 'first'),
+        min_depth=('Alternate Allele Depth', 'min'),
+        max_depth=('Alternate Allele Depth', 'max'),
+        mean_depth=('Alternate Allele Depth', lambda x: sum(x) / len(x)),
+        min_af=('Alternate Allele Frequency', 'min'),
+        max_af=('Alternate Allele Frequency', 'max'),
+        mean_af=('Alternate Allele Frequency', lambda x: sum(x) / len(x)),
     )
-    return df_summary.rename(columns={x: y for x, y, _ in variant_summary_cols})
+    return df_summary.rename(columns={x: y for x, y, _ in (variant_summary_cols + variants_cols)})

--- a/xlavir/util.py
+++ b/xlavir/util.py
@@ -36,6 +36,7 @@ def extract_sample_name(filename: str,
     if not remove:
         remove = [
             '.trim',
+            '.ivar_trim',
             '.mkD',
             '.sorted',
             '.bam',

--- a/xlavir/xlavir.py
+++ b/xlavir/xlavir.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 from xlavir import qc
 from xlavir.io import ct
 from xlavir.io.excel_sheet_dataframe import ExcelSheetDataFrame, SheetName
-from xlavir.tools import mosdepth, samtools, consensus, pangolin, variants
+from xlavir.tools import mosdepth, samtools, consensus, pangolin, variants, nextclade
 from xlavir.tools.nextflow import exec_report
 from xlavir.tools.nextflow.exec_report import to_dataframe
 
@@ -49,6 +49,12 @@ def run(input_dir: Path,
                                        df=df_pangolin,
                                        pd_to_excel_kwargs=dict(freeze_panes=(1, 1)),
                                        header_comments={x: y for _, x, y in pangolin.pangolin_cols}))
+    sample_nextclade = nextclade.get_info(basedir=input_dir)
+    if sample_nextclade:
+        dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.nextclade.value,
+                                       df=nextclade.to_dataframe(sample_nextclade),
+                                       pd_to_excel_kwargs=dict(freeze_panes=(1, 1)),
+                                       header_comments={x: y for _, x, y in nextclade.nextclade_cols}))
     if sample_variants:
         df_variants = variants.to_dataframe(sample_variants.values())
         dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.variants.value,
@@ -61,7 +67,8 @@ def run(input_dir: Path,
             dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.varsum.value,
                                            df=df_varsum,
                                            pd_to_excel_kwargs=dict(freeze_panes=(1, 1)),
-                                           header_comments={name: desc for _, name, desc in variants.variant_summary_cols}))
+                                           header_comments={name: desc for _, name, desc in
+                                                            variants.variant_summary_cols + variants.variants_cols}))
             df_varmap = variants.to_variant_pivot_table(df_variants)
             max_index_length = df_varmap.index.str.len().max()
             dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.varmat.value,

--- a/xlavir/xlavir.py
+++ b/xlavir/xlavir.py
@@ -62,17 +62,18 @@ def run(input_dir: Path,
                                            df=df_varsum,
                                            pd_to_excel_kwargs=dict(freeze_panes=(1, 1)),
                                            header_comments={name: desc for _, name, desc in variants.variant_summary_cols}))
+            df_varmap = variants.to_variant_pivot_table(df_variants)
+            max_index_length = df_varmap.index.str.len().max()
+            dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.varmat.value,
+                                           df=df_varmap,
+                                           pd_to_excel_kwargs=dict(freeze_panes=(1, 1), na_rep=0.0),
+                                           autofit=False,
+                                           column_widths=[max_index_length + 2] + [3 for _ in
+                                                                                   range(df_varmap.columns.size)]))
         else:
             logger.warning(f'No column "Mutation" found in variant info dataframe. SnpEff/SnpSift table may not have '
                            f'been found or parsed correctly.')
-        df_varmap = variants.to_variant_pivot_table(df_variants)
-        max_index_length = df_varmap.index.str.len().max()
-        dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.varmat.value,
-                                       df=df_varmap,
-                                       pd_to_excel_kwargs=dict(freeze_panes=(1, 1), na_rep=0.0),
-                                       autofit=False,
-                                       column_widths=[max_index_length + 2] + [3 for _ in
-                                                                               range(df_varmap.columns.size)]))
+
     dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.consensus.value,
                                    df=consensus.get_info(basedir=input_dir),
                                    autofit=False,

--- a/xlavir/xlavir.py
+++ b/xlavir/xlavir.py
@@ -56,11 +56,15 @@ def run(input_dir: Path,
                                        pd_to_excel_kwargs=dict(freeze_panes=(1, 1)),
                                        include_header_width=False,
                                        header_comments={name: desc for _, name, desc in variants.variants_cols}))
-        df_varsum = variants.to_summary(df_variants)
-        dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.varsum.value,
-                                       df=df_varsum,
-                                       pd_to_excel_kwargs=dict(freeze_panes=(1, 1)),
-                                       header_comments={name: desc for _, name, desc in variants.variant_summary_cols}))
+        if 'Mutation' in df_variants.columns:
+            df_varsum = variants.to_summary(df_variants)
+            dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.varsum.value,
+                                           df=df_varsum,
+                                           pd_to_excel_kwargs=dict(freeze_panes=(1, 1)),
+                                           header_comments={name: desc for _, name, desc in variants.variant_summary_cols}))
+        else:
+            logger.warning(f'No column "Mutation" found in variant info dataframe. SnpEff/SnpSift table may not have '
+                           f'been found or parsed correctly.')
         df_varmap = variants.to_variant_pivot_table(df_variants)
         max_index_length = df_varmap.index.str.len().max()
         dfs.append(ExcelSheetDataFrame(sheet_name=SheetName.varmat.value,


### PR DESCRIPTION
# Changes

- add SnpSift and Pangolin file glob and sample name extraction patterns
- add warning when "Mutation" field does not exist in variants table;  do not try to create variant matrix if "Mutation" field does not exist in variants table
- add descriptions for new fields for Pangolin>=2.4

# todo

- [X] ~workaround for Mosdepth `per-base.bed.gz` not output by viralrecon v2.0 by default; pysam parsing of trimmed bam file? run samtools depth on bam file?~ (custom modules.config file required for running nf-core/viralrecon v2.0)
- [X] nextclade results parsing (`**/nextclade/*.csv`)
- [X] per sample summary of SNPs, MNPs, indels, missense mutations, etc *(get this with Nextclade)*