### PR TITLE
Fix Mosdepth single position reported as 0-based

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.4.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/peterk87/xlavir',
-    version='0.4.2',
+    version='0.4.3',
     zip_safe=False,
 )

--- a/xlavir/__init__.py
+++ b/xlavir/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Peter Kruczkiewicz"""
 __email__ = 'peter.kruczkiewicz@gmail.com'
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/xlavir/tools/mosdepth.py
+++ b/xlavir/tools/mosdepth.py
@@ -51,7 +51,7 @@ def get_interval_coords_bed(df: pd.DataFrame, threshold: int = 0) -> str:
                 coords.append([x, y - 1])
         else:
             coords.append([x, y - 1])
-    return '; '.join([f'{xs[0] + 1}-{xs[-1] + 1}' if xs[0] != xs[-1] else f'{xs[0]}' for xs in coords])
+    return '; '.join([f'{xs[0] + 1}-{xs[-1] + 1}' if xs[0] != xs[-1] else f'{xs[0] + 1}' for xs in coords])
 
 
 def count_positions(df: pd.DataFrame) -> int:


### PR DESCRIPTION
Fix an issue where single base positions are being reported as 0-based when all other ranges are 1-based for reporting of low/no coverage regions from Mosdepth per-base BED files.