### PR TITLE
Fixes for creating reports for large non-SARS-CoV-2 viruses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,25 @@
 History
 =======
 
+0.5.2 (2021-11-08)
+------------------
+
+Fixes and changes from PR `#15 <https://github.com/peterk87/xlavir/issues/15>`_
+
+Fixes:
+
+* low coverage coordinate output off by one (``xlavir.tools.mosdepth.get_interval_coords_bed``)
+* error on no Pangolin reports found (e.g. non-SARS-CoV-2 report) (``xlavir.tools.pangolin.get_info``)
+* user QC thresholds not being used (``xlavir.xlavir.run``)
+* not showing all QC fail comments (``xlavir.qc.create_qc_stats_dataframe``)
+* consensus sequences being too long for Excel cell character limit (32,767 characters); longer sequences are chunked into 80 character segments with one segment per line in consensus sheet  (``xlavir.tools.consensus.read_fasta``)
+
+Changes:
+
+* Ignore and skip unsupported VCFs instead of throwing NotImplementedError (``xlavir.tools.variants.get_info``)
+* In consensus sheet, only add QC comments on FASTA header rows if necessary (``xlavir.io.xl.add_comments``)
+
+
 0.5.1 (2021-08-04)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.1
+current_version = 0.5.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/peterk87/xlavir',
-    version='0.5.1',
+    version='0.5.2',
     zip_safe=False,
 )

--- a/xlavir/__init__.py
+++ b/xlavir/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Peter Kruczkiewicz"""
 __email__ = 'peter.kruczkiewicz@gmail.com'
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/xlavir/io/xl.py
+++ b/xlavir/io/xl.py
@@ -381,7 +381,6 @@ def add_comments(xlsx_path: Path,
                     f'samples in sheet "{SheetName.consensus.value}".')
         highlight_seq = False
         sample_name = ''
-
         dark_red = '260000'
         for i, row in enumerate(sheet.rows):
             cell = row[0]
@@ -389,6 +388,7 @@ def add_comments(xlsx_path: Path,
                 sample_name = cell.value[1:]
                 if sample_name in failed_samples:
                     highlight_seq = True
+                    # only add comment to cell containing failing sample fasta header
                     cell.comment = Comment(f'Warning: Sample "{sample_name}" has failed general NGS QC',
                                            author='xlavir')
                     cell.fill = PatternFill(fill_type='solid', fgColor=light_red)
@@ -398,23 +398,19 @@ def add_comments(xlsx_path: Path,
                                      size=font.size,
                                      family=font.family)
                 else:
+                    highlight_seq = False
                     font: Font = cell.font
                     cell.font = Font(name='Courier New',
                                      color='000000',
                                      size=font.size,
                                      family=font.family)
-                    highlight_seq = False
             elif cell.value and highlight_seq:
-                cell.comment = Comment(f'Warning: Sample "{sample_name}" has failed general NGS QC',
-                                       author='xlavir')
-
                 cell.fill = PatternFill(fill_type='solid', fgColor=light_red)
                 font: Font = cell.font
                 cell.font = Font(name='Courier New',
                                  color=dark_red,
                                  size=font.size,
                                  family=font.family)
-                highlight_seq = False
             else:
                 font: Font = cell.font
                 cell.font = Font(name='Courier New',

--- a/xlavir/qc/__init__.py
+++ b/xlavir/qc/__init__.py
@@ -115,7 +115,7 @@ def create_qc_stats_dataframe(sample_depth_info: Dict[str, mosdepth.MosdepthDept
             comments += [f'Genome coverage below {quality_reqs.min_genome_coverage:.0%}']
         qc_comments.append('; '.join(comments))
     df_stats['qc_comment'] = qc_comments
-    df_stats.loc[mask_pass_breadth, 'qc_comment'] = ''
+    df_stats.loc[qc_pass_mask, 'qc_comment'] = ''
     df_stats.sort_values('sample', inplace=True)
 
     present_cols = set(df_stats.columns)

--- a/xlavir/tools/mosdepth.py
+++ b/xlavir/tools/mosdepth.py
@@ -38,7 +38,8 @@ def read_mosdepth_bed(p: Path) -> pd.DataFrame:
 
 
 def get_interval_coords_bed(df: pd.DataFrame, threshold: int = 0) -> str:
-    df_below = df[df.depth <= threshold]
+    mask = df.depth == 0 if threshold == 0 else df.depth < threshold
+    df_below = df[mask]
     start_pos, end_pos = df_below.start_idx, df_below.end_idx
     coords = []
     for x, y in zip(start_pos, end_pos):

--- a/xlavir/tools/pangolin.py
+++ b/xlavir/tools/pangolin.py
@@ -98,4 +98,7 @@ def get_info(basedir: Path,
             pangolin_outputs = find_file_for_each_sample(basedir=basedir,
                                                          glob_patterns=PANGOLIN_GLOB_PATTERNS,
                                                          sample_name_cleanup=PANGOLIN_SAMPLE_NAME_CLEANUP)
-            return pd.concat([read_pangolin_csv(p, s) for s, p in pangolin_outputs.items()])
+            if pangolin_outputs:
+                return pd.concat([read_pangolin_csv(p, s) for s, p in pangolin_outputs.items()])
+            else:
+                return None

--- a/xlavir/tools/variants.py
+++ b/xlavir/tools/variants.py
@@ -474,7 +474,7 @@ def get_info(basedir: Path) -> Dict[str, pd.DataFrame]:
             else:
                 logger.warning(f'Sample "{sample}" has no entries in VCF "{vcf_path}"')
         else:
-            logger.warning(f'Sample "{sample}" VCF file "{vcf_path}" with {variant_caller=} not supported. Skipping...')
+            logger.warning(f'Sample "{sample}" VCF file "{vcf_path}" with variant_caller={variant_caller} not supported. Skipping...')
 
     sample_snpsift = find_file_for_each_sample(basedir=basedir,
                                                glob_patterns=SNPSIFT_GLOB_PATTERNS,

--- a/xlavir/tools/variants.py
+++ b/xlavir/tools/variants.py
@@ -473,7 +473,7 @@ def get_info(basedir: Path) -> Dict[str, pd.DataFrame]:
             else:
                 logger.warning(f'Sample "{sample}" has no entries in VCF "{vcf_path}"')
         else:
-            raise NotImplementedError()
+            logger.warning(f'Sample "{sample}" VCF file "{vcf_path}" with {variant_caller=} not supported. Skipping...')
 
     sample_snpsift = find_file_for_each_sample(basedir=basedir,
                                                glob_patterns=SNPSIFT_GLOB_PATTERNS,

--- a/xlavir/tools/variants.py
+++ b/xlavir/tools/variants.py
@@ -1,3 +1,4 @@
+"""VCF and SnpEff/SnpSift parsing functions"""
 import logging
 import os
 import re

--- a/xlavir/xlavir.py
+++ b/xlavir/xlavir.py
@@ -17,7 +17,7 @@ def run(input_dir: Path,
         quality_reqs: Optional[qc.QualityRequirements],
         pangolin_lineage_csv: Optional[Path] = None,
         ct_values_table: Optional[Path] = None) -> List[ExcelSheetDataFrame]:
-    if quality_reqs:
+    if quality_reqs is None:
         quality_reqs = qc.QualityRequirements()
     nf_exec_info = exec_report.get_info(input_dir)
     sample_depth_info = mosdepth.get_info(input_dir, low_coverage_threshold=quality_reqs.low_coverage_threshold)


### PR DESCRIPTION
Fixes:

* low coverage coordinate output (off by one) (`xlavir.tools.mosdepth.get_interval_coords_bed`)
* error on no Pangolin reports found (non-SARS-CoV-2 report) (`xlavir.tools.pangolin.get_info`)
* user QC reqs thresholds not being used (`xlavir.xlavir.run`)
* not showing all QC fail comments (`xlavir.qc.create_qc_stats_dataframe`)
* consensus sequences being too long for max Excel cell character limit (>32k) (`xlavir.tools.consensus.read_fasta`)

Changes:

* Ignore unsupported VCFs instead of throwing NotImplementedError (`xlavir.tools.variants.get_info`)
* In consensus sheet, only add QC comments on header rows if necessary (`xlavir.io.xl.add_comments`)

Bump version: 0.5.1 → 0.5.2