### PR TITLE
Fix low/no coverage sample Medaka VCF parsing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.6.1 (2022-02-01)
+------------------
+
+* Added more checks for Medaka VCFs from low coverage samples which may produce ValueError and ZeroDivisionError errors
+
+
 0.6.0 (2022-01-05)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/peterk87/xlavir',
-    version='0.6.0',
+    version='0.6.1',
     zip_safe=False,
 )

--- a/xlavir/__init__.py
+++ b/xlavir/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Peter Kruczkiewicz"""
 __email__ = 'peter.kruczkiewicz@gmail.com'
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/xlavir/tools/variants.py
+++ b/xlavir/tools/variants.py
@@ -462,7 +462,11 @@ def parse_medaka_vcf(df: pd.DataFrame, sample_name: str = None, qc_reqs: Quality
         ac_ref_fwd, ac_ref_rev, ac_alt_fwd, ac_alt_rev = infos['SR']
         infos['REF_DP'] = ac_ref_fwd + ac_ref_rev
         infos['ALT_DP'] = ac_alt_fwd + ac_alt_rev
+        if infos['REF_DP'] + infos['ALT_DP'] < qc_reqs.low_coverage_threshold:
+            continue
         pos_info_val[row.POS] = infos
+    if pos_info_val == {}:
+        return None
     df_medaka_info = pd.DataFrame(pos_info_val).transpose()
     df_medaka_info.index.name = 'POS'
     df_medaka_info.reset_index(inplace=True)


### PR DESCRIPTION
- Added more checks for Medaka VCFs from low coverage samples which may produce ValueError and ZeroDivisionError errors.
- Bumped to version 0.6.1 for patch release.